### PR TITLE
Fix some issues with android button

### DIFF
--- a/android/src/main/java/com/clipsub/RNSweetAlert/RNSweetAlertModule.java
+++ b/android/src/main/java/com/clipsub/RNSweetAlert/RNSweetAlertModule.java
@@ -31,6 +31,11 @@ public class RNSweetAlertModule extends ReactContextBaseJavaModule {
     String contentText = options.hasKey("subTitle") ? options.getString("subTitle") : "";
     String barColor = options.hasKey("barColor") ? options.getString("barColor") : "";
     boolean cancellable = !options.hasKey("cancellable") || options.getBoolean("cancellable");
+    String confirmButtonColor = options.hasKey("confirmButtonColor") ? options.getString("confirmButtonColor") : "";
+    String confirmButtonTitle = options.hasKey("confirmButtonTitle") ? options.getString("confirmButtonTitle") : "OK";
+    String otherButtonTitle = options.hasKey("otherButtonTitle") ? options.getString("otherButtonTitle") : "";
+    String otherButtonColor = options.hasKey("otherButtonColor") ? options.getString("otherButtonColor") : "";
+
     switch (type) {
       case "normal":
         sweetAlertDialog.changeAlertType(SweetAlertDialog.NORMAL_TYPE);
@@ -65,12 +70,25 @@ public class RNSweetAlertModule extends ReactContextBaseJavaModule {
         sweetAlertDialog.dismissWithAnimation();
       }
     });
+    if (!otherButtonTitle.equals("")) {
+      sweetAlertDialog.showCancelButton(true);
+      sweetAlertDialog.setCancelText(otherButtonTitle);
+      if (!otherButtonColor.equals("")) {
+        sweetAlertDialog.setCancelButtonBackgroundColor(Color.parseColor(otherButtonColor));
+      }
+    }
     sweetAlertDialog.setTitleText(title);
     sweetAlertDialog.setContentText(contentText);
     sweetAlertDialog.setCancelable(cancellable);
+    sweetAlertDialog.setConfirmText(confirmButtonTitle);
     if (!barColor.equals("")) {
       setBarColor(barColor);
     }
+    sweetAlertDialog.setCancelable(cancellable);
+    if (!confirmButtonColor.equals("")) {
+      sweetAlertDialog.setConfirmButtonBackgroundColor(Color.parseColor(confirmButtonColor));
+    }
+
     sweetAlertDialog.show();
   }
 

--- a/index.js
+++ b/index.js
@@ -16,14 +16,14 @@ const DEFAULT_OPTIONS = {
   confirmButtonTitle: 'OK',
   confirmButtonColor: '#000000',
   barColor: '',
-  otherButtonTitle: 'Cancel',
-  otherButtonColor: '#dedede',
+  otherButtonTitle: '',
+  otherButtonColor: '',
   style: 'success',
   cancellable: true
 }
 
 const SweetAlert = {
-  showAlertWithOptions: (options, callback = () => {}) => {
+  showAlertWithOptions: (options, callback = () => { }) => {
     Native.showAlertWithOptions(options ? options : DEFAULT_OPTIONS, callback)
   },
   dismissAlert: () => Native.hideSweetAlert(),


### PR DESCRIPTION
I solved some problems written in this issue:
https://github.com/acaziasoftcom/react-native-sweet-alert/issues/13
that were not resolving
connect this options and change some default values to choose if want the cancel button or not, options:
confirmButtonTitle:,
confirmButtonColor: ,
otherButtonTitle: ,
otherButtonColor: ,
i use the some functions from https://github.com/pedant/sweet-alert-dialog
that have already used in the project
